### PR TITLE
Changes required by changes in ckeditor5-engine.

### DIFF
--- a/tests/undocommand.js
+++ b/tests/undocommand.js
@@ -221,7 +221,7 @@ describe( 'UndoCommand', () => {
 			expect( root.childCount ).to.equal( 1 );
 			expect( itemAt( root, 0 ).name ).to.equal( 'p' );
 
-			expect( editor.document.selection.getFirstRange().isEqual( r( 0, 0 ) ) ).to.be.true;
+			expect( editor.document.selection.getFirstRange().isEqual( r( 1, 1 ) ) ).to.be.true;
 			expect( editor.document.selection.isBackward ).to.be.false;
 
 			undo._execute( batch1 );
@@ -233,7 +233,7 @@ describe( 'UndoCommand', () => {
 			expect( itemAt( root, 0 ).name ).to.equal( 'p' );
 
 			// Operations for undoing that batch were working on graveyard so document selection should not change.
-			expect( editor.document.selection.getFirstRange().isEqual( r( 0, 0 ) ) ).to.be.true;
+			expect( editor.document.selection.getFirstRange().isEqual( r( 1, 1 ) ) ).to.be.true;
 			expect( editor.document.selection.isBackward ).to.be.false;
 
 			expect( doc.graveyard.getChild( 0 ).maxOffset ).to.equal( 6 );

--- a/tests/undoengine-integration.js
+++ b/tests/undoengine-integration.js
@@ -228,7 +228,7 @@ describe( 'UndoEngine integration', () => {
 			input( 'fo[zb]ar' );
 
 			doc.batch().wrap( doc.selection.getFirstRange(), 'p' );
-			output( 'fo[<p>zb</p>]ar' );
+			output( 'fo<p>[zb]</p>ar' );
 
 			editor.execute( 'undo' );
 			output( 'fo[zb]ar' );
@@ -242,7 +242,7 @@ describe( 'UndoEngine integration', () => {
 
 			doc.batch().wrap( doc.selection.getFirstRange(), 'p' );
 			// Would be better if selection was inside P.
-			output( 'fo[<p>zb</p>]ar' );
+			output( 'fo<p>[zb]</p>ar' );
 
 			setSelection( [ 2, 0 ], [ 2, 1 ] );
 			doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 0 ] ) );


### PR DESCRIPTION
Changes required by https://github.com/ckeditor/ckeditor5-engine/pull/700

Only selection position has changed in tests. This is not a big UX concern because we never had any strict rule how the selection should be positioned.