### PR TITLE
Simplified undo commands due to simplification in engine.model.History.

### DIFF
--- a/src/basecommand.js
+++ b/src/basecommand.js
@@ -79,7 +79,7 @@ export default class BaseCommand extends Command {
 	 * @protected
 	 * @param {Array.<module:engine/model/range~Range>} ranges Ranges to be restored.
 	 * @param {Boolean} isBackward A flag describing whether the restored range was selected forward or backward.
-	 * @param {Array.<module:engine/model/delta~Delta>} deltas Deltas which has been applied since selection has been stored.
+	 * @param {Array.<module:engine/model/delta/delta~Delta>} deltas Deltas which has been applied since selection has been stored.
 	 */
 	_restoreSelection( ranges, isBackward, deltas ) {
 		const document = this.editor.document;
@@ -113,7 +113,7 @@ export default class BaseCommand extends Command {
 
 	/**
 	 * Undoes a batch by reversing that batch, transforming reversed batch and finally applying it.
-	 * This is a helper method for {@link #_doExecute}.
+	 * This is a helper method for {@link #execute}.
 	 *
 	 * @protected
 	 * @param {module:engine/model/batch~Batch} batchToUndo The batch to be undone.
@@ -135,13 +135,12 @@ export default class BaseCommand extends Command {
 			// deltas, so we need arrays to handle them. To simplify algorithms, it is better to always operate on arrays.
 			const nextBaseVersion = deltaToUndo.baseVersion + deltaToUndo.operations.length;
 
-			// 2. Reverse delta from the history.
-			// let reversedDelta = [ deltaToUndo.getReversed() ];
+			// Reverse delta from the history.
 			const historyDeltas = Array.from( document.history.getDeltas( nextBaseVersion ) );
 			const transformedSets = document.transformDeltas( [ deltaToUndo.getReversed() ], historyDeltas, true );
 			const reversedDeltas = transformedSets.deltasA;
 
-			// 4. After reversed delta has been transformed by all history deltas, apply it.
+			// After reversed delta has been transformed by all history deltas, apply it.
 			for ( const delta of reversedDeltas ) {
 				// Fix base version.
 				delta.baseVersion = document.version;
@@ -162,17 +161,14 @@ export default class BaseCommand extends Command {
 	}
 }
 
-// Transforms given range `range` by deltas from `document` history, starting from a delta with given `baseVersion`.
+// Transforms given range `range` by given `deltas`.
 // Returns an array containing one or more ranges, which are result of the transformation.
 function transformSelectionRange( range, deltas ) {
-	// The range will be transformed by history deltas that happened after the selection got stored.
-	// Note, that at this point, the document history is already updated by undo command execution. We will
-	// not transform the range by deltas that got undone or their reversing counterparts.
 	const transformed = transformRangesByDeltas( [ range ], deltas );
 
 	// After `range` got transformed, we have an array of ranges. Some of those
 	// ranges may be "touching" -- they can be next to each other and could be merged.
-	// First, we have to sort those ranges because they don't have to be in an order.
+	// First, we have to sort those ranges to assure that they are in order.
 	transformed.sort( ( a, b ) => a.start.isBefore( b.start ) ? -1 : 1 );
 
 	// Then, we check if two consecutive ranges are touching.
@@ -181,6 +177,7 @@ function transformSelectionRange( range, deltas ) {
 		const b = transformed[ i ];
 
 		if ( a.end.isTouching( b.start ) ) {
+			// And join them together if they are.
 			a.end = b.end;
 			transformed.splice( i, 1 );
 			i--;

--- a/src/redocommand.js
+++ b/src/redocommand.js
@@ -12,11 +12,10 @@ import BaseCommand from './basecommand';
 /**
  * The redo command stores {@link module:engine/model/batch~Batch batches} that were used to undo a batch by
  * {@link module:undo/undocommand~UndoCommand}. It is able to redo a previously undone batch by reversing the undoing
- * batches created by `UndoCommand`. The reversed batch is also transformed by batches from
- * {@link module:engine/model/document~Document#history history} that happened after it and are not other redo batches.
+ * batches created by `UndoCommand`. The reversed batch is transformed by all the batches from
+ * {@link module:engine/model/document~Document#history history} that happened after the reversed undo batch.
  *
- * The redo command also takes care of restoring the {@link module:engine/model/document~Document#selection document selection}
- * to the state before an undone batch was applied.
+ * The redo command also takes care of restoring the {@link module:engine/model/document~Document#selection document selection}.
  *
  * @extends module:undo/basecommand~BaseCommand
  */

--- a/src/redocommand.js
+++ b/src/redocommand.js
@@ -8,7 +8,6 @@
  */
 
 import BaseCommand from './basecommand';
-import deltaTransform from '@ckeditor/ckeditor5-engine/src/model/delta/transform';
 
 /**
  * The redo command stores {@link module:engine/model/batch~Batch batches} that were used to undo a batch by
@@ -38,73 +37,12 @@ export default class RedoCommand extends BaseCommand {
 		this.editor.document.enqueueChanges( () => {
 			const lastDelta = item.batch.deltas[ item.batch.deltas.length - 1 ];
 			const nextBaseVersion = lastDelta.baseVersion + lastDelta.operations.length;
-
-			// Selection state is from the moment after undo happened. It needs to be transformed by all the deltas
-			// that happened after the selection state got saved. Unfortunately it is tricky, because those deltas
-			// are already compressed in the history (they are removed).
-			// Because of that we will transform the selection only by non-redo deltas
-			const deltas = Array.from( this.editor.document.history.getDeltas( nextBaseVersion ) ).filter( delta => {
-				return !this._createdBatches.has( delta.batch );
-			} );
+			const deltas = this.editor.document.history.getDeltas( nextBaseVersion );
 
 			this._restoreSelection( item.selection.ranges, item.selection.isBackward, deltas );
-			this._redo( item.batch );
+			this._undo( item.batch );
 		} );
 
 		this.refresh();
-	}
-
-	/**
-	 * Redoes a batch by reversing the batch that has undone it, transforming that batch and applying it. This is
-	 * a helper method for {@link #execute}.
-	 *
-	 * @private
-	 * @param {module:engine/model/batch~Batch} storedBatch The batch whose deltas will be reversed, transformed and applied.
-	 */
-	_redo( storedBatch ) {
-		const document = this.editor.document;
-
-		// All changes done by the command execution will be saved as one batch.
-		const redoingBatch = document.batch();
-		this._createdBatches.add( redoingBatch );
-
-		const deltasToRedo = storedBatch.deltas.slice();
-		deltasToRedo.reverse();
-
-		// We will process each delta from `storedBatch`, in reverse order. If there was deltas A, B and C in stored batch,
-		// we need to revert them in reverse order, so first reverse C, then B, then A.
-		for ( const deltaToRedo of deltasToRedo ) {
-			// Keep in mind that all algorithms return arrays. That's because the transformation might result in multiple
-			// deltas, so we need arrays to handle them anyway. To simplify algorithms, it is better to always have arrays
-			// in mind. For simplicity reasons, we will use singular form in descriptions and names.
-
-			const nextBaseVersion = deltaToRedo.baseVersion + deltaToRedo.operations.length;
-
-			// As stated above, convert delta to array of deltas.
-			let reversedDelta = [ deltaToRedo.getReversed() ];
-
-			// 1. Transform that delta by deltas from history that happened after it.
-			// Omit deltas from "redo" batches, because reversed delta already bases on them. Transforming by them
-			// again will result in incorrect deltas.
-			for ( const historyDelta of document.history.getDeltas( nextBaseVersion ) ) {
-				if ( !this._createdBatches.has( historyDelta.batch ) ) {
-					reversedDelta = deltaTransform.transformDeltaSets( reversedDelta, [ historyDelta ], true ).deltasA;
-				}
-			}
-
-			// 2. After reversed delta has been transformed by all history deltas, apply it.
-			for ( const delta of reversedDelta ) {
-				// Fix base version.
-				delta.baseVersion = document.version;
-
-				// Before applying, add the delta to the `redoingBatch`.
-				redoingBatch.addDelta( delta );
-
-				// Now, apply all operations of the delta.
-				for ( const operation of delta.operations ) {
-					document.applyOperation( operation );
-				}
-			}
-		}
 	}
 }

--- a/src/undocommand.js
+++ b/src/undocommand.js
@@ -12,10 +12,9 @@ import BaseCommand from './basecommand';
 /**
  * The undo command stores {@link module:engine/model/batch~Batch batches} applied to the
  * {@link module:engine/model/document~Document document} and is able to undo a batch by reversing it and transforming by
- * other batches from {@link module:engine/model/document~Document#history history} that happened after the reversed batch.
+ * batches from {@link module:engine/model/document~Document#history history} that happened after the reversed batch.
  *
- * The undo command also takes care of restoring the {@link module:engine/model/document~Document#selection document selection}
- * to the state before the undone batch was applied.
+ * The undo command also takes care of restoring the {@link module:engine/model/document~Document#selection document selection}.
  *
  * @extends module:undo/basecommand~BaseCommand
  */

--- a/src/undocommand.js
+++ b/src/undocommand.js
@@ -7,8 +7,7 @@
  * @module undo/undocommand
  */
 
-import { default as BaseCommand, transformRangesByDeltas } from './basecommand';
-import deltaTransform from '@ckeditor/ckeditor5-engine/src/model/delta/transform';
+import BaseCommand from './basecommand';
 
 /**
  * The undo command stores {@link module:engine/model/batch~Batch batches} applied to the
@@ -48,139 +47,6 @@ export default class UndoCommand extends BaseCommand {
 		} );
 
 		this.refresh();
-	}
-
-	/**
-	 * Returns an index in {@link module:undo/basecommand~BaseCommand#_stack} pointing to the item that is storing a
-	 * batch that has a given {@link module:engine/model/batch~Batch#baseVersion}.
-	 *
-	 * @private
-	 * @param {Number} baseVersion The base version of the batch to find.
-	 * @returns {Number|null}
-	 */
-	_getItemIndexFromBaseVersion( baseVersion ) {
-		for ( let i = 0; i < this._stack.length; i++ ) {
-			if ( this._stack[ i ].batch.baseVersion == baseVersion ) {
-				return i;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Undoes a batch by reversing a batch from history, transforming that reversed batch and applying it. This is
-	 * a helper method for {@link #execute}.
-	 *
-	 * @private
-	 * @param {module:engine/model/batch~Batch} batchToUndo A batch whose deltas will be reversed, transformed and applied.
-	 */
-	_undo( batchToUndo ) {
-		const document = this.editor.document;
-
-		// All changes done by the command execution will be saved as one batch.
-		const undoingBatch = document.batch();
-		this._createdBatches.add( undoingBatch );
-
-		const history = document.history;
-		const deltasToUndo = batchToUndo.deltas.slice();
-		deltasToUndo.reverse();
-
-		// We will process each delta from `batchToUndo`, in reverse order. If there was deltas A, B and C in undone batch,
-		// we need to revert them in reverse order, so first reverse C, then B, then A.
-		for ( const deltaToUndo of deltasToUndo ) {
-			// Keep in mind that all algorithms return arrays. That's because the transformation might result in multiple
-			// deltas, so we need arrays to handle them anyway. To simplify algorithms, it is better to always have arrays
-			// in mind. For simplicity reasons, we will use singular form in descriptions and names.
-			const baseVersion = deltaToUndo.baseVersion;
-			const nextBaseVersion = baseVersion + deltaToUndo.operations.length;
-
-			// 1. Get updated version of the delta from the history.
-			// Batch stored in the undo command might have an outdated version of the delta that should be undone.
-			// To prevent errors, we will take an updated version of it from the history, basing on delta's `baseVersion`.
-			const updatedDeltaToUndo = history.getDelta( baseVersion );
-
-			// This is a safe valve in case of not finding delta to undo in history. This may come up if that delta
-			// got updated into no deltas, or removed from history.
-			if ( updatedDeltaToUndo === null ) {
-				continue;
-			}
-
-			// 2. Reverse delta from the history.
-			updatedDeltaToUndo.reverse();
-			let reversedDelta = [];
-
-			for ( const delta of updatedDeltaToUndo ) {
-				reversedDelta.push( delta.getReversed() );
-			}
-
-			// Stores history deltas transformed by `deltaToUndo`. Will be used later for updating document history.
-			const updatedHistoryDeltas = {};
-
-			// 3. Transform reversed delta by history deltas that happened after delta to undo. We have to bring
-			// reversed delta to the current state of document. While doing this, we will also update history deltas
-			// to the state which "does not remember" delta that we undo.
-			for ( const historyDelta of history.getDeltas( nextBaseVersion ) ) {
-				// 3.1. Transform selection range stored with history batch by reversed delta.
-				// It is important to keep stored selection ranges updated. As we are removing and updating deltas in the history,
-				// selection ranges would base on outdated history state.
-				const itemIndex = this._getItemIndexFromBaseVersion( historyDelta.baseVersion );
-
-				// `itemIndex` will be `null` for `historyDelta` if it is not the first delta in it's batch.
-				// This is fine, because we want to transform each selection only once, before transforming reversed delta
-				// by the first delta of the batch connected with the ranges.
-				if ( itemIndex !== null ) {
-					this._stack[ itemIndex ].selection.ranges = transformRangesByDeltas(
-						this._stack[ itemIndex ].selection.ranges, reversedDelta
-					);
-				}
-
-				// 3.2. Transform reversed delta by history delta and vice-versa.
-				const results = deltaTransform.transformDeltaSets( reversedDelta, [ historyDelta ], true );
-
-				reversedDelta = results.deltasA;
-				const updatedHistoryDelta = results.deltasB;
-
-				// 3.3. Store updated history delta. Later, it will be updated in `history`.
-				if ( !updatedHistoryDeltas[ historyDelta.baseVersion ] ) {
-					updatedHistoryDeltas[ historyDelta.baseVersion ] = [];
-				}
-
-				const mergedHistoryDeltas = updatedHistoryDeltas[ historyDelta.baseVersion ].concat( updatedHistoryDelta );
-				updatedHistoryDeltas[ historyDelta.baseVersion ] = mergedHistoryDeltas;
-			}
-
-			// 4. After reversed delta has been transformed by all history deltas, apply it.
-			for ( const delta of reversedDelta ) {
-				// Fix base version.
-				delta.baseVersion = document.version;
-
-				// Before applying, add the delta to the `undoingBatch`.
-				undoingBatch.addDelta( delta );
-
-				// Now, apply all operations of the delta.
-				for ( const operation of delta.operations ) {
-					document.applyOperation( operation );
-				}
-			}
-
-			// 5. Remove reversed delta from the history.
-			history.removeDelta( baseVersion );
-
-			// And all deltas that are reversing it.
-			// So the history looks like both original and reversing deltas never happened.
-			// That's why we have to update history deltas - some of them might have been basing on deltas that we are now removing.
-			for ( const delta of reversedDelta ) {
-				history.removeDelta( delta.baseVersion );
-			}
-
-			// 6. Update history deltas in history.
-			for ( const historyBaseVersion in updatedHistoryDeltas ) {
-				history.updateDelta( Number( historyBaseVersion ), updatedHistoryDeltas[ historyBaseVersion ] );
-			}
-		}
-
-		return undoingBatch;
 	}
 }
 

--- a/tests/undocommand.js
+++ b/tests/undocommand.js
@@ -249,12 +249,11 @@ describe( 'UndoCommand', () => {
 					expect( char.hasAttribute( 'key' ) ).to.be.false;
 				}
 
-				// Let's undo wrapping. This will bring back some nodes that were wrapped into the paragraph at the beginning.
+				// Let's undo wrapping. This will remove the P element and leave us with empty root.
 				undo.execute( batch3 );
-				expect( root.maxOffset ).to.equal( 3 );
-				expect( root.getChild( 0 ).data ).to.equal( 'bar' );
+				expect( root.maxOffset ).to.equal( 0 );
 
-				expect( editor.document.selection.getFirstRange().isEqual( r( 0, 3 ) ) ).to.be.true;
+				expect( editor.document.selection.getFirstRange().isEqual( r( 0, 0 ) ) ).to.be.true;
 				expect( editor.document.selection.isBackward ).to.be.false;
 			} );
 		} );

--- a/tests/undoengine-integration.js
+++ b/tests/undoengine-integration.js
@@ -40,312 +40,310 @@ describe( 'UndoEngine integration', () => {
 		expect( editor.commands.get( 'undo' ).isEnabled ).to.be.false;
 	}
 
-	describe( 'UndoEngine integration', () => {
-		describe( 'adding and removing content', () => {
-			it( 'add and undo', () => {
-				input( '<p>fo[]o</p><p>bar</p>' );
+	describe( 'adding and removing content', () => {
+		it( 'add and undo', () => {
+			input( '<p>fo[]o</p><p>bar</p>' );
 
-				doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
-				output( '<p>fozzz[]o</p><p>bar</p>' );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
+			output( '<p>fozzz[]o</p><p>bar</p>' );
 
-				editor.execute( 'undo' );
-				output( '<p>fo[]o</p><p>bar</p>' );
+			editor.execute( 'undo' );
+			output( '<p>fo[]o</p><p>bar</p>' );
 
-				undoDisabled();
-			} );
-
-			it( 'multiple adding and undo', () => {
-				input( '<p>fo[]o</p><p>bar</p>' );
-
-				doc.batch()
-					.insert( doc.selection.getFirstPosition(), 'zzz' )
-					.insert( new Position( root, [ 1, 0 ] ), 'xxx' );
-				output( '<p>fozzz[]o</p><p>xxxbar</p>' );
-
-				setSelection( [ 1, 0 ], [ 1, 0 ] );
-				doc.batch().insert( doc.selection.getFirstPosition(), 'yyy' );
-				output( '<p>fozzzo</p><p>yyy[]xxxbar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fozzzo</p><p>[]xxxbar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fo[]o</p><p>bar</p>' );
-
-				undoDisabled();
-			} );
-
-			it( 'multiple adding mixed with undo', () => {
-				input( '<p>fo[]o</p><p>bar</p>' );
-
-				doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
-				output( '<p>fozzz[]o</p><p>bar</p>' );
-
-				setSelection( [ 1, 0 ], [ 1, 0 ] );
-				doc.batch().insert( doc.selection.getFirstPosition(), 'yyy' );
-				output( '<p>fozzzo</p><p>yyy[]bar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fozzzo</p><p>[]bar</p>' );
-
-				setSelection( [ 0, 0 ], [ 0, 0 ] );
-				doc.batch().insert( doc.selection.getFirstPosition(), 'xxx' );
-				output( '<p>xxx[]fozzzo</p><p>bar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>[]fozzzo</p><p>bar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fo[]o</p><p>bar</p>' );
-
-				undoDisabled();
-			} );
-
-			it( 'multiple remove and undo', () => {
-				input( '<p>[]foo</p><p>bar</p>' );
-
-				doc.batch().remove( Range.createFromPositionAndShift( doc.selection.getFirstPosition(), 2 ) );
-				output( '<p>[]o</p><p>bar</p>' );
-
-				setSelection( [ 1, 1 ], [ 1, 1 ] );
-				doc.batch().remove( Range.createFromPositionAndShift( doc.selection.getFirstPosition(), 2 ) );
-				output( '<p>o</p><p>b[]</p>' );
-
-				editor.execute( 'undo' );
-				// Here is an edge case that selection could be before or after `ar`.
-				output( '<p>o</p><p>b[]ar</p>' );
-
-				editor.execute( 'undo' );
-				// As above.
-				output( '<p>[]foo</p><p>bar</p>' );
-
-				undoDisabled();
-			} );
-
-			it( 'add and remove different parts and undo', () => {
-				input( '<p>fo[]o</p><p>bar</p>' );
-
-				doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
-				output( '<p>fozzz[]o</p><p>bar</p>' );
-
-				setSelection( [ 1, 2 ], [ 1, 2 ] );
-				doc.batch().remove( Range.createFromPositionAndShift( new Position( root, [ 1, 1 ] ), 1 ) );
-				output( '<p>fozzzo</p><p>b[]r</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fozzzo</p><p>ba[]r</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fo[]o</p><p>bar</p>' );
-
-				undoDisabled();
-			} );
-
-			it( 'add and remove same part and undo', () => {
-				input( '<p>fo[]o</p><p>bar</p>' );
-
-				doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
-				output( '<p>fozzz[]o</p><p>bar</p>' );
-
-				doc.batch().remove( Range.createFromPositionAndShift( new Position( root, [ 0, 2 ] ), 3 ) );
-				output( '<p>fo[]o</p><p>bar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fozzz[]o</p><p>bar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fo[]o</p><p>bar</p>' );
-
-				undoDisabled();
-			} );
+			undoDisabled();
 		} );
 
-		describe( 'moving', () => {
-			it( 'move same content twice then undo', () => {
-				input( '<p>f[o]z</p><p>bar</p>' );
+		it( 'multiple adding and undo', () => {
+			input( '<p>fo[]o</p><p>bar</p>' );
 
-				doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 1, 0 ] ) );
-				output( '<p>fz</p><p>[o]bar</p>' );
+			doc.batch()
+				.insert( doc.selection.getFirstPosition(), 'zzz' )
+				.insert( new Position( root, [ 1, 0 ] ), 'xxx' );
+			output( '<p>fozzz[]o</p><p>xxxbar</p>' );
 
-				doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 0, 2 ] ) );
-				output( '<p>fz[o]</p><p>bar</p>' );
+			setSelection( [ 1, 0 ], [ 1, 0 ] );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'yyy' );
+			output( '<p>fozzzo</p><p>yyy[]xxxbar</p>' );
 
-				editor.execute( 'undo' );
-				output( '<p>fz</p><p>[o]bar</p>' );
+			editor.execute( 'undo' );
+			output( '<p>fozzzo</p><p>[]xxxbar</p>' );
 
-				editor.execute( 'undo' );
-				output( '<p>f[o]z</p><p>bar</p>' );
+			editor.execute( 'undo' );
+			output( '<p>fo[]o</p><p>bar</p>' );
 
-				undoDisabled();
-			} );
-
-			it( 'move content and new parent then undo', () => {
-				input( '<p>f[o]z</p><p>bar</p>' );
-
-				doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 1, 0 ] ) );
-				output( '<p>fz</p><p>[o]bar</p>' );
-
-				setSelection( [ 1 ], [ 2 ] );
-				doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 0 ] ) );
-				output( '[<p>obar</p>]<p>fz</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>fz</p>[<p>obar</p>]' );
-
-				editor.execute( 'undo' );
-				output( '<p>f[o]z</p><p>bar</p>' );
-
-				undoDisabled();
-			} );
+			undoDisabled();
 		} );
 
-		describe( 'attributes with other', () => {
-			it( 'attributes then insert inside then undo', () => {
-				input( '<p>fo[ob]ar</p>' );
+		it( 'multiple adding mixed with undo', () => {
+			input( '<p>fo[]o</p><p>bar</p>' );
 
-				doc.batch().setAttribute( doc.selection.getFirstRange(), 'bold', true );
-				output( '<p>fo[<$text bold="true">ob</$text>]ar</p>' );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
+			output( '<p>fozzz[]o</p><p>bar</p>' );
 
-				setSelection( [ 0, 3 ], [ 0, 3 ] );
-				doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
-				output( '<p>fo<$text bold="true">o</$text>zzz<$text bold="true">[]b</$text>ar</p>' );
-				expect( doc.selection.getAttribute( 'bold' ) ).to.true;
+			setSelection( [ 1, 0 ], [ 1, 0 ] );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'yyy' );
+			output( '<p>fozzzo</p><p>yyy[]bar</p>' );
 
-				editor.execute( 'undo' );
-				output( '<p>fo<$text bold="true">o[]b</$text>ar</p>' );
-				expect( doc.selection.getAttribute( 'bold' ) ).to.true;
+			editor.execute( 'undo' );
+			output( '<p>fozzzo</p><p>[]bar</p>' );
 
-				editor.execute( 'undo' );
-				output( '<p>fo[ob]ar</p>' );
+			setSelection( [ 0, 0 ], [ 0, 0 ] );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'xxx' );
+			output( '<p>xxx[]fozzzo</p><p>bar</p>' );
 
-				undoDisabled();
-			} );
+			editor.execute( 'undo' );
+			output( '<p>[]fozzzo</p><p>bar</p>' );
+
+			editor.execute( 'undo' );
+			output( '<p>fo[]o</p><p>bar</p>' );
+
+			undoDisabled();
 		} );
 
-		describe( 'wrapping, unwrapping, merging, splitting', () => {
-			it( 'wrap and undo', () => {
-				doc.schema.allow( { name: '$text', inside: '$root' } );
-				input( 'fo[zb]ar' );
+		it( 'multiple remove and undo', () => {
+			input( '<p>[]foo</p><p>bar</p>' );
 
-				doc.batch().wrap( doc.selection.getFirstRange(), 'p' );
-				output( 'fo<p>[zb]</p>ar' );
+			doc.batch().remove( Range.createFromPositionAndShift( doc.selection.getFirstPosition(), 2 ) );
+			output( '<p>[]o</p><p>bar</p>' );
 
-				editor.execute( 'undo' );
-				output( 'fo[zb]ar' );
+			setSelection( [ 1, 1 ], [ 1, 1 ] );
+			doc.batch().remove( Range.createFromPositionAndShift( doc.selection.getFirstPosition(), 2 ) );
+			output( '<p>o</p><p>b[]</p>' );
 
-				undoDisabled();
-			} );
+			editor.execute( 'undo' );
+			// Here is an edge case that selection could be before or after `ar`.
+			output( '<p>o</p><p>bar[]</p>' );
 
-			it( 'wrap, move and undo', () => {
-				doc.schema.allow( { name: '$text', inside: '$root' } );
-				input( 'fo[zb]ar' );
+			editor.execute( 'undo' );
+			// As above.
+			output( '<p>fo[]o</p><p>bar</p>' );
 
-				doc.batch().wrap( doc.selection.getFirstRange(), 'p' );
-				// Would be better if selection was inside P.
-				output( 'fo<p>[zb]</p>ar' );
-
-				setSelection( [ 2, 0 ], [ 2, 1 ] );
-				doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 0 ] ) );
-				output( '[z]fo<p>b</p>ar' );
-
-				editor.execute( 'undo' );
-				output( 'fo<p>[z]b</p>ar' );
-
-				editor.execute( 'undo' );
-				output( 'fo[zb]ar' );
-
-				undoDisabled();
-			} );
-
-			it( 'unwrap and undo', () => {
-				input( '<p>foo[]bar</p>' );
-
-				doc.batch().unwrap( doc.selection.getFirstPosition().parent );
-				output( 'foo[]bar' );
-
-				editor.execute( 'undo' );
-				output( '<p>foo[]bar</p>' );
-
-				undoDisabled();
-			} );
-
-			it( 'merge and undo', () => {
-				input( '<p>foo</p><p>[]bar</p>' );
-
-				doc.batch().merge( new Position( root, [ 1 ] ) );
-				// Because selection is stuck with <p> it ends up in graveyard. We have to manually move it to correct node.
-				setSelection( [ 0, 3 ], [ 0, 3 ] );
-				output( '<p>foo[]bar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>foo</p><p>[]bar</p>' );
-
-				undoDisabled();
-			} );
-
-			it( 'split and undo', () => {
-				input( '<p>foo[]bar</p>' );
-
-				doc.batch().split( doc.selection.getFirstPosition() );
-				// Because selection is stuck with <p> it ends up in wrong node. We have to manually move it to correct node.
-				setSelection( [ 1, 0 ], [ 1, 0 ] );
-				output( '<p>foo</p><p>[]bar</p>' );
-
-				editor.execute( 'undo' );
-				output( '<p>foo[]bar</p>' );
-
-				undoDisabled();
-			} );
+			undoDisabled();
 		} );
 
-		describe( 'other edge cases', () => {
-			it( 'deleteContent between two nodes', () => {
-				input( '<p>fo[o</p><p>b]ar</p>' );
+		it( 'add and remove different parts and undo', () => {
+			input( '<p>fo[]o</p><p>bar</p>' );
 
-				editor.data.deleteContent( doc.selection, doc.batch() );
-				output( '<p>fo[]ar</p>' );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
+			output( '<p>fozzz[]o</p><p>bar</p>' );
 
-				editor.execute( 'undo' );
-				output( '<p>fo[o</p><p>b]ar</p>' );
-			} );
+			setSelection( [ 1, 2 ], [ 1, 2 ] );
+			doc.batch().remove( Range.createFromPositionAndShift( new Position( root, [ 1, 1 ] ), 1 ) );
+			output( '<p>fozzzo</p><p>b[]r</p>' );
 
-			// Related to ckeditor5-engine#891 and ckeditor5-list#51.
-			it( 'change attribute of removed node then undo and redo', () => {
-				const gy = doc.graveyard;
-				const batch = doc.batch();
-				const p = new Element( 'p' );
+			editor.execute( 'undo' );
+			output( '<p>fozzzo</p><p>ba[]r</p>' );
 
-				root.appendChildren( p );
+			editor.execute( 'undo' );
+			output( '<p>fo[]o</p><p>bar</p>' );
 
-				batch.remove( p );
-				batch.setAttribute( p, 'bold', true );
+			undoDisabled();
+		} );
 
-				editor.execute( 'undo' );
-				editor.execute( 'redo' );
+		it( 'add and remove same part and undo', () => {
+			input( '<p>fo[]o</p><p>bar</p>' );
 
-				expect( p.root ).to.equal( gy );
-				expect( p.getAttribute( 'bold' ) ).to.be.true;
-			} );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
+			output( '<p>fozzz[]o</p><p>bar</p>' );
 
-			// Related to ckeditor5-engine#891.
-			it( 'change attribute of removed node then undo and redo', () => {
-				const gy = doc.graveyard;
-				const batch = doc.batch();
-				const p1 = new Element( 'p' );
-				const p2 = new Element( 'p' );
-				const p3 = new Element( 'p' );
+			doc.batch().remove( Range.createFromPositionAndShift( new Position( root, [ 0, 2 ] ), 3 ) );
+			output( '<p>fo[]o</p><p>bar</p>' );
 
-				root.appendChildren( [ p1, p2 ] );
+			editor.execute( 'undo' );
+			output( '<p>fozzz[]o</p><p>bar</p>' );
 
-				batch.remove( p1 ).remove( p2 ).insert( new Position( root, [ 0 ] ), p3 );
+			editor.execute( 'undo' );
+			output( '<p>fo[]o</p><p>bar</p>' );
 
-				editor.execute( 'undo' );
-				editor.execute( 'redo' );
+			undoDisabled();
+		} );
+	} );
 
-				expect( p1.root ).to.equal( gy );
-				expect( p2.root ).to.equal( gy );
-				expect( p3.root ).to.equal( root );
-			} );
+	describe( 'moving', () => {
+		it( 'move same content twice then undo', () => {
+			input( '<p>f[o]z</p><p>bar</p>' );
+
+			doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 1, 0 ] ) );
+			output( '<p>fz</p><p>[o]bar</p>' );
+
+			doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 0, 2 ] ) );
+			output( '<p>fz[o]</p><p>bar</p>' );
+
+			editor.execute( 'undo' );
+			output( '<p>fz</p><p>[o]bar</p>' );
+
+			editor.execute( 'undo' );
+			output( '<p>f[o]z</p><p>bar</p>' );
+
+			undoDisabled();
+		} );
+
+		it( 'move content and new parent then undo', () => {
+			input( '<p>f[o]z</p><p>bar</p>' );
+
+			doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 1, 0 ] ) );
+			output( '<p>fz</p><p>[o]bar</p>' );
+
+			setSelection( [ 1 ], [ 2 ] );
+			doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 0 ] ) );
+			output( '[<p>obar</p>]<p>fz</p>' );
+
+			editor.execute( 'undo' );
+			output( '<p>fz</p>[<p>obar</p>]' );
+
+			editor.execute( 'undo' );
+			output( '<p>f[o]z</p><p>bar</p>' );
+
+			undoDisabled();
+		} );
+	} );
+
+	describe( 'attributes with other', () => {
+		it( 'attributes then insert inside then undo', () => {
+			input( '<p>fo[ob]ar</p>' );
+
+			doc.batch().setAttribute( doc.selection.getFirstRange(), 'bold', true );
+			output( '<p>fo[<$text bold="true">ob</$text>]ar</p>' );
+
+			setSelection( [ 0, 3 ], [ 0, 3 ] );
+			doc.batch().insert( doc.selection.getFirstPosition(), 'zzz' );
+			output( '<p>fo<$text bold="true">o</$text>zzz<$text bold="true">[]b</$text>ar</p>' );
+			expect( doc.selection.getAttribute( 'bold' ) ).to.true;
+
+			editor.execute( 'undo' );
+			output( '<p>fo<$text bold="true">o[]b</$text>ar</p>' );
+			expect( doc.selection.getAttribute( 'bold' ) ).to.true;
+
+			editor.execute( 'undo' );
+			output( '<p>fo[ob]ar</p>' );
+
+			undoDisabled();
+		} );
+	} );
+
+	describe( 'wrapping, unwrapping, merging, splitting', () => {
+		it( 'wrap and undo', () => {
+			doc.schema.allow( { name: '$text', inside: '$root' } );
+			input( 'fo[zb]ar' );
+
+			doc.batch().wrap( doc.selection.getFirstRange(), 'p' );
+			output( 'fo<p>[zb]</p>ar' );
+
+			editor.execute( 'undo' );
+			output( 'fo[zb]ar' );
+
+			undoDisabled();
+		} );
+
+		it( 'wrap, move and undo', () => {
+			doc.schema.allow( { name: '$text', inside: '$root' } );
+			input( 'fo[zb]ar' );
+
+			doc.batch().wrap( doc.selection.getFirstRange(), 'p' );
+			// Would be better if selection was inside P.
+			output( 'fo<p>[zb]</p>ar' );
+
+			setSelection( [ 2, 0 ], [ 2, 1 ] );
+			doc.batch().move( doc.selection.getFirstRange(), new Position( root, [ 0 ] ) );
+			output( '[z]fo<p>b</p>ar' );
+
+			editor.execute( 'undo' );
+			output( 'fo<p>[z]b</p>ar' );
+
+			editor.execute( 'undo' );
+			output( 'fo[zb]ar' );
+
+			undoDisabled();
+		} );
+
+		it( 'unwrap and undo', () => {
+			input( '<p>foo[]bar</p>' );
+
+			doc.batch().unwrap( doc.selection.getFirstPosition().parent );
+			output( 'foo[]bar' );
+
+			editor.execute( 'undo' );
+			output( '<p>foo[]bar</p>' );
+
+			undoDisabled();
+		} );
+
+		it( 'merge and undo', () => {
+			input( '<p>foo</p><p>[]bar</p>' );
+
+			doc.batch().merge( new Position( root, [ 1 ] ) );
+			// Because selection is stuck with <p> it ends up in graveyard. We have to manually move it to correct node.
+			setSelection( [ 0, 3 ], [ 0, 3 ] );
+			output( '<p>foo[]bar</p>' );
+
+			editor.execute( 'undo' );
+			output( '<p>foo</p><p>bar[]</p>' );
+
+			undoDisabled();
+		} );
+
+		it( 'split and undo', () => {
+			input( '<p>foo[]bar</p>' );
+
+			doc.batch().split( doc.selection.getFirstPosition() );
+			// Because selection is stuck with <p> it ends up in wrong node. We have to manually move it to correct node.
+			setSelection( [ 1, 0 ], [ 1, 0 ] );
+			output( '<p>foo</p><p>[]bar</p>' );
+
+			editor.execute( 'undo' );
+			output( '<p>foobar[]</p>' );
+
+			undoDisabled();
+		} );
+	} );
+
+	describe( 'other edge cases', () => {
+		it( 'deleteContent between two nodes', () => {
+			input( '<p>fo[o</p><p>b]ar</p>' );
+
+			editor.data.deleteContent( doc.selection, doc.batch() );
+			output( '<p>fo[]ar</p>' );
+
+			editor.execute( 'undo' );
+			output( '<p>fo[o</p><p>b]ar</p>' );
+		} );
+
+		// Related to ckeditor5-engine#891 and ckeditor5-list#51.
+		it( 'change attribute of removed node then undo and redo', () => {
+			const gy = doc.graveyard;
+			const batch = doc.batch();
+			const p = new Element( 'p' );
+
+			root.appendChildren( p );
+
+			batch.remove( p );
+			batch.setAttribute( p, 'bold', true );
+
+			editor.execute( 'undo' );
+			editor.execute( 'redo' );
+
+			expect( p.root ).to.equal( gy );
+			expect( p.getAttribute( 'bold' ) ).to.be.true;
+		} );
+
+		// Related to ckeditor5-engine#891.
+		it( 'change attribute of removed node then undo and redo', () => {
+			const gy = doc.graveyard;
+			const batch = doc.batch();
+			const p1 = new Element( 'p' );
+			const p2 = new Element( 'p' );
+			const p3 = new Element( 'p' );
+
+			root.appendChildren( [ p1, p2 ] );
+
+			batch.remove( p1 ).remove( p2 ).insert( new Position( root, [ 0 ] ), p3 );
+
+			editor.execute( 'undo' );
+			editor.execute( 'redo' );
+
+			expect( p1.root ).to.equal( gy );
+			expect( p2.root ).to.equal( gy );
+			expect( p3.root ).to.equal( root );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Undo algorithms got simplified thanks to changes in `engine.model`: `History`, `RemoveOperation`, contextual OT.