### PR TITLE
Do not restore selection if selection had only a default range

### DIFF
--- a/src/basecommand.js
+++ b/src/basecommand.js
@@ -56,9 +56,11 @@ export default class BaseCommand extends Command {
 	 * @param {module:engine/model/batch~Batch} batch The batch to add.
 	 */
 	addBatch( batch ) {
+		const docSelection = this.editor.document.selection;
+
 		const selection = {
-			ranges: Array.from( this.editor.document.selection.getRanges() ),
-			isBackward: this.editor.document.selection.isBackward
+			ranges: docSelection.hasOwnRange ? Array.from( docSelection.getRanges() ) : [],
+			isBackward: docSelection.isBackward
 		};
 
 		this._stack.push( { batch, selection } );

--- a/tests/undoengine-integration.js
+++ b/tests/undoengine-integration.js
@@ -179,6 +179,48 @@ describe( 'UndoEngine integration', () => {
 
 			undoDisabled();
 		} );
+
+		it( 'undo remove all content', () => {
+			input( '<p>foo[]</p>' );
+
+			doc.batch().remove( Range.createIn( root ) );
+			output( '[]' );
+
+			editor.execute( 'undo' );
+			output( '<p>foo[]</p>' );
+
+			undoDisabled();
+		} );
+
+		it( 'undo insert first content', () => {
+			input( '' );
+
+			doc.batch().insert( doc.selection.getFirstPosition(), new Element( 'p' ) );
+			output( '<p>[]</p>' );
+
+			editor.execute( 'undo' );
+			output( '[]' );
+
+			undoDisabled();
+		} );
+
+		// #72.
+		it( 'undo paste multiple elements simulation', () => {
+			input( '<p></p>' );
+
+			const p = root.getChild( 0 );
+			const pos = new Position( root, [ 0 ] );
+
+			doc.batch().remove( p ).insert( pos, new Element( 'p' ) ).insert( pos.getShiftedBy( 1 ), new Element( 'p' ) );
+
+			output( '<p>[]</p><p></p>' );
+
+			editor.execute( 'undo' );
+
+			output( '<p>[]</p>' );
+
+			undoDisabled();
+		} );
 	} );
 
 	describe( 'moving', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Selection was incorrectly restored when undo after all editor contents where replaced or removed. Closes #72.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-engine/pull/1138.