### PR TITLE
Undo and redo commands pass batches to enqueueChange method.

### DIFF
--- a/src/basecommand.js
+++ b/src/basecommand.js
@@ -8,7 +8,6 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 
 /**
  * Base class for undo feature commands: {@link module:undo/undocommand~UndoCommand} and {@link module:undo/redocommand~RedoCommand}.
@@ -123,13 +122,13 @@ export default class BaseCommand extends Command {
 	 *
 	 * @protected
 	 * @param {module:engine/model/batch~Batch} batchToUndo The batch to be undone.
+	 * @param {module:engine/model/batch~Batch} undoingBatch The batch with undoing changes.
 	 */
-	_undo( batchToUndo ) {
+	_undo( batchToUndo, undoingBatch ) {
 		const model = this.editor.model;
 		const document = model.document;
 
 		// All changes done by the command execution will be saved as one batch.
-		const undoingBatch = new Batch();
 		this._createdBatches.add( undoingBatch );
 
 		const deltasToUndo = batchToUndo.deltas.slice();
@@ -168,8 +167,6 @@ export default class BaseCommand extends Command {
 				}
 			}
 		}
-
-		return undoingBatch;
 	}
 }
 

--- a/src/basecommand.js
+++ b/src/basecommand.js
@@ -122,7 +122,7 @@ export default class BaseCommand extends Command {
 	 *
 	 * @protected
 	 * @param {module:engine/model/batch~Batch} batchToUndo The batch to be undone.
-	 * @param {module:engine/model/batch~Batch} undoingBatch The batch with undoing changes.
+	 * @param {module:engine/model/batch~Batch} undoingBatch The batch that will contain undoing changes.
 	 */
 	_undo( batchToUndo, undoingBatch ) {
 		const model = this.editor.model;

--- a/src/undocommand.js
+++ b/src/undocommand.js
@@ -8,6 +8,7 @@
  */
 
 import BaseCommand from './basecommand';
+import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 
 /**
  * The undo command stores {@link module:engine/model/batch~Batch batches} applied to the
@@ -33,11 +34,12 @@ export default class UndoCommand extends BaseCommand {
 		const batchIndex = batch ? this._stack.findIndex( a => a.batch == batch ) : this._stack.length - 1;
 
 		const item = this._stack.splice( batchIndex, 1 )[ 0 ];
+		const undoingBatch = new Batch();
 
 		// All changes has to be done in one `enqueueChange` callback so other listeners will not
 		// step between consecutive deltas, or won't do changes to the document before selection is properly restored.
-		this.editor.model.enqueueChange( () => {
-			const undoingBatch = this._undo( item.batch );
+		this.editor.model.enqueueChange( undoingBatch, () => {
+			this._undo( item.batch, undoingBatch );
 
 			const deltas = this.editor.model.document.history.getDeltas( item.batch.baseVersion );
 			this._restoreSelection( item.selection.ranges, item.selection.isBackward, deltas );

--- a/tests/redocommand.js
+++ b/tests/redocommand.js
@@ -270,6 +270,23 @@ describe( 'RedoCommand', () => {
 				expect( editor.model.document.selection.getFirstRange().isEqual( r( 4, 6 ) ) ).to.be.true;
 				expect( editor.model.document.selection.isBackward ).to.be.false;
 			} );
+
+			it( 'should pass redoing batch to enqueueChange method', () => {
+				undo.execute( batch2 );
+
+				const enqueueChangeSpy = sinon.spy( model, 'enqueueChange' );
+				const undoSpy = sinon.spy( redo, '_undo' );
+
+				redo.execute();
+
+				sinon.assert.calledOnce( enqueueChangeSpy );
+				sinon.assert.calledOnce( undoSpy );
+
+				const redoingbatch = enqueueChangeSpy.firstCall.args[ 0 ];
+
+				expect( redoingbatch instanceof Batch ).to.be.true;
+				expect( undoSpy.firstCall.args[ 1 ] ).to.equal( redoingbatch );
+			} );
 		} );
 	} );
 } );

--- a/tests/redocommand.js
+++ b/tests/redocommand.js
@@ -282,10 +282,10 @@ describe( 'RedoCommand', () => {
 				sinon.assert.calledOnce( enqueueChangeSpy );
 				sinon.assert.calledOnce( undoSpy );
 
-				const redoingbatch = enqueueChangeSpy.firstCall.args[ 0 ];
+				const redoingBatch = enqueueChangeSpy.firstCall.args[ 0 ];
 
-				expect( redoingbatch instanceof Batch ).to.be.true;
-				expect( undoSpy.firstCall.args[ 1 ] ).to.equal( redoingbatch );
+				expect( redoingBatch instanceof Batch ).to.be.true;
+				expect( undoSpy.firstCall.args[ 1 ] ).to.equal( redoingBatch );
 			} );
 		} );
 	} );

--- a/tests/undocommand.js
+++ b/tests/undocommand.js
@@ -297,6 +297,21 @@ describe( 'UndoCommand', () => {
 				expect( element.getAttribute( 'foo' ) ).to.equal( 'bar' );
 				expect( root.getAttribute( 'foo' ) ).to.not.equal( 'bar' );
 			} );
+
+			it( 'should pass undoing batch to enqueueChange method', () => {
+				const enqueueChangeSpy = sinon.spy( model, 'enqueueChange' );
+				const undoSpy = sinon.spy( undo, '_undo' );
+
+				undo.execute();
+
+				sinon.assert.calledOnce( enqueueChangeSpy );
+				sinon.assert.calledOnce( undoSpy );
+
+				const undoingBatch = enqueueChangeSpy.firstCall.args[ 0 ];
+
+				expect( undoingBatch instanceof Batch ).to.be.true;
+				expect( undoSpy.firstCall.args[ 1 ] ).to.equal( undoingBatch );
+			} );
 		} );
 
 		it( 'merges touching ranges when restoring selection', () => {

--- a/tests/undoediting-integration.js
+++ b/tests/undoediting-integration.js
@@ -1055,7 +1055,7 @@ describe( 'UndoEditing integration', () => {
 		// 1. Step - add text and marker to the paragraph.
 		model.change( writer => {
 			writer.appendText( 'foo', paragraph );
-			writer.setMarker( 'marker', Range.createIn( paragraph ) );
+			writer.setMarker( 'marker', Range.createIn( paragraph ), { usingOperation: true } );
 		} );
 
 		// 2. Step - remove text from paragraph.

--- a/tests/undoediting-integration.js
+++ b/tests/undoediting-integration.js
@@ -48,6 +48,10 @@ describe( 'UndoEditing integration', () => {
 			} );
 	} );
 
+	afterEach( () => {
+		return editor.destroy();
+	} );
+
 	function setSelection( pathA, pathB ) {
 		model.change( writer => {
 			writer.setSelection( new Range( new Position( root, pathA ), new Position( root, pathB ) ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Undo and redo commands pass batches to enqueueChange method. Closes #84.
