### PR TITLE
transformSets is now exported as a function, not inside an object

### DIFF
--- a/src/basecommand.js
+++ b/src/basecommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import transform from '@ckeditor/ckeditor5-engine/src/model/operation/transform';
+import { transformSets } from '@ckeditor/ckeditor5-engine/src/model/operation/transform';
 
 /**
  * Base class for undo feature commands: {@link module:undo/undocommand~UndoCommand} and {@link module:undo/redocommand~RedoCommand}.
@@ -142,7 +142,7 @@ export default class BaseCommand extends Command {
 			const nextBaseVersion = operationToUndo.baseVersion + 1;
 			const historyOperations = Array.from( document.history.getOperations( nextBaseVersion ) );
 
-			const transformedSets = transform.transformSets(
+			const transformedSets = transformSets(
 				[ operationToUndo.getReversed() ],
 				historyOperations,
 				{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `transformSets` is now exported as a function, not inside an object.