### PR TITLE
Remove Position, Range, Selection imports from engine/model.

### DIFF
--- a/src/redocommand.js
+++ b/src/redocommand.js
@@ -8,7 +8,6 @@
  */
 
 import BaseCommand from './basecommand';
-import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 
 /**
  * The redo command stores {@link module:engine/model/batch~Batch batches} that were used to undo a batch by
@@ -31,7 +30,7 @@ export default class RedoCommand extends BaseCommand {
 	 */
 	execute() {
 		const item = this._stack.pop();
-		const redoingBatch = new Batch();
+		const redoingBatch = this.editor.model.createBatch();
 
 		// All changes have to be done in one `enqueueChange` callback so other listeners will not step between consecutive
 		// operations, or won't do changes to the document before selection is properly restored.

--- a/src/undocommand.js
+++ b/src/undocommand.js
@@ -8,7 +8,6 @@
  */
 
 import BaseCommand from './basecommand';
-import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 
 /**
  * The undo command stores {@link module:engine/model/batch~Batch batches} applied to the
@@ -34,7 +33,7 @@ export default class UndoCommand extends BaseCommand {
 		const batchIndex = batch ? this._stack.findIndex( a => a.batch == batch ) : this._stack.length - 1;
 
 		const item = this._stack.splice( batchIndex, 1 )[ 0 ];
-		const undoingBatch = new Batch();
+		const undoingBatch = this.editor.model.createBatch();
 
 		// All changes has to be done in one `enqueueChange` callback so other listeners will not
 		// step between consecutive operations, or won't do changes to the document before selection is properly restored.

--- a/tests/basecommand.js
+++ b/tests/basecommand.js
@@ -4,7 +4,6 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
-import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 import BaseCommand from '../src/basecommand';
 
 describe( 'BaseCommand', () => {
@@ -31,7 +30,7 @@ describe( 'BaseCommand', () => {
 		} );
 
 		it( 'should be true if there are batches in command stack', () => {
-			base.addBatch( new Batch() );
+			base.addBatch( editor.model.createBatch() );
 
 			expect( base.isEnabled ).to.be.true;
 		} );
@@ -39,7 +38,7 @@ describe( 'BaseCommand', () => {
 
 	describe( 'clearStack', () => {
 		it( 'should remove all batches from the stack', () => {
-			base.addBatch( new Batch() );
+			base.addBatch( editor.model.createBatch() );
 			base.clearStack();
 
 			expect( base.isEnabled ).to.be.false;

--- a/tests/redocommand.js
+++ b/tests/redocommand.js
@@ -4,8 +4,6 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
-import Range from '@ckeditor/ckeditor5-engine/src/model/range';
-import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 import UndoCommand from '../src/undocommand';
 import RedoCommand from '../src/redocommand';
@@ -30,8 +28,8 @@ describe( 'RedoCommand', () => {
 
 	describe( 'RedoCommand', () => {
 		describe( 'execute()', () => {
-			const p = pos => new Position( root, [].concat( pos ) );
-			const r = ( a, b ) => new Range( p( a ), p( b ) );
+			const p = pos => model.createPositionFromPath( root, [].concat( pos ) );
+			const r = ( a, b ) => model.createRange( p( a ), p( b ) );
 
 			let batch0, batch1, batch2;
 			const batches = new Set();
@@ -55,7 +53,7 @@ describe( 'RedoCommand', () => {
 					writer.setSelection( r( 0, 0 ) );
 				} );
 
-				batch0 = new Batch();
+				batch0 = model.createBatch();
 				undo.addBatch( batch0 );
 				model.enqueueChange( batch0, writer => {
 					writer.insertText( 'foobar', p( 0 ) );
@@ -74,7 +72,7 @@ describe( 'RedoCommand', () => {
 				model.change( writer => {
 					writer.setSelection( r( 2, 4 ), { backward: true } );
 				} );
-				batch1 = new Batch();
+				batch1 = model.createBatch();
 				undo.addBatch( batch1 );
 				model.enqueueChange( batch1, writer => {
 					writer.setAttribute( 'key', 'value', r( 2, 4 ) );
@@ -92,7 +90,7 @@ describe( 'RedoCommand', () => {
 				model.change( writer => {
 					writer.setSelection( r( 1, 3 ) );
 				} );
-				batch2 = new Batch();
+				batch2 = model.createBatch();
 				undo.addBatch( batch2 );
 				model.enqueueChange( batch2, writer => {
 					writer.move( r( 1, 3 ), p( 6 ) );

--- a/tests/undocommand.js
+++ b/tests/undocommand.js
@@ -4,8 +4,6 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
-import Range from '@ckeditor/ckeditor5-engine/src/model/range';
-import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 import UndoCommand from '../src/undocommand';
 import { itemAt, getText } from '@ckeditor/ckeditor5-engine/tests/model/_utils/utils';
@@ -29,8 +27,8 @@ describe( 'UndoCommand', () => {
 	} );
 
 	describe( 'UndoCommand', () => {
-		const p = pos => new Position( root, [].concat( pos ) );
-		const r = ( a, b ) => new Range( p( a ), p( b ) );
+		const p = pos => model.createPositionFromPath( root, [].concat( pos ) );
+		const r = ( a, b ) => model.createRange( p( a ), p( b ) );
 
 		describe( 'execute()', () => {
 			let batch0, batch1, batch2, batch3;
@@ -43,7 +41,7 @@ describe( 'UndoCommand', () => {
 				model.change( writer => {
 					writer.setSelection( r( 0, 0 ) );
 				} );
-				batch0 = new Batch();
+				batch0 = model.createBatch();
 				undo.addBatch( batch0 );
 				model.enqueueChange( batch0, writer => {
 					writer.insertText( 'foobar', p( 0 ) );
@@ -62,7 +60,7 @@ describe( 'UndoCommand', () => {
 				model.change( writer => {
 					writer.setSelection( r( 2, 4 ), { backward: true } );
 				} );
-				batch1 = new Batch();
+				batch1 = model.createBatch();
 				undo.addBatch( batch1 );
 				model.enqueueChange( batch1, writer => {
 					writer.setAttribute( 'key', 'value', r( 2, 4 ) );
@@ -80,7 +78,7 @@ describe( 'UndoCommand', () => {
 				model.change( writer => {
 					writer.setSelection( r( 1, 3 ) );
 				} );
-				batch2 = new Batch();
+				batch2 = model.createBatch();
 				undo.addBatch( batch2 );
 				model.enqueueChange( batch2, writer => {
 					writer.move( r( 1, 3 ), p( 6 ) );
@@ -98,7 +96,7 @@ describe( 'UndoCommand', () => {
 				model.change( writer => {
 					writer.setSelection( r( 1, 4 ) );
 				} );
-				batch3 = new Batch();
+				batch3 = model.createBatch();
 				undo.addBatch( batch3 );
 				model.enqueueChange( batch3, writer => {
 					writer.wrap( r( 1, 4 ), 'p' );
@@ -265,7 +263,7 @@ describe( 'UndoCommand', () => {
 				// Graveyard contains "foobar".
 				expect( doc.graveyard.maxOffset ).to.equal( 6 );
 
-				for ( const item of Range.createIn( doc.graveyard ).getItems() ) {
+				for ( const item of model.createRangeIn( doc.graveyard ).getItems() ) {
 					expect( item.hasAttribute( 'key' ) ).to.be.false;
 				}
 
@@ -332,7 +330,7 @@ describe( 'UndoCommand', () => {
 			model.change( writer => {
 				writer.setSelection( r( 1, 4 ) );
 			} );
-			const batch0 = new Batch();
+			const batch0 = model.createBatch();
 			undo.addBatch( batch0 );
 			model.enqueueChange( batch0, writer => {
 				writer.setAttribute( 'uppercase', true, r( 1, 4 ) );
@@ -342,7 +340,7 @@ describe( 'UndoCommand', () => {
 			model.change( writer => {
 				writer.setSelection( r( 3, 4 ) );
 			} );
-			const batch1 = new Batch();
+			const batch1 = model.createBatch();
 			undo.addBatch( batch1 );
 			model.enqueueChange( batch1, writer => {
 				writer.move( r( 3, 4 ), p( 1 ) );

--- a/tests/undoediting.js
+++ b/tests/undoediting.js
@@ -4,7 +4,7 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
-import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
+
 import UndoEditing from '../src/undoediting';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
@@ -60,7 +60,7 @@ describe( 'UndoEditing', () => {
 		sinon.spy( undo._undoCommand, 'addBatch' );
 		sinon.spy( undo._redoCommand, 'clearStack' );
 
-		const batch = new Batch();
+		const batch = model.createBatch();
 
 		undo._redoCommand._createdBatches.add( batch );
 
@@ -76,7 +76,7 @@ describe( 'UndoEditing', () => {
 		sinon.spy( undo._redoCommand, 'addBatch' );
 		sinon.spy( undo._redoCommand, 'clearStack' );
 
-		undo._undoCommand.fire( 'revert', null, new Batch() );
+		undo._undoCommand.fire( 'revert', null, model.createBatch() );
 
 		expect( undo._redoCommand.addBatch.calledOnce ).to.be.true;
 		expect( undo._redoCommand.clearStack.called ).to.be.false;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove Position, Range, Selection imports from engine/model and engine/view.

---

### Additional information

* Part of: https://github.com/ckeditor/ckeditor5-engine/pull/1585.
