### PR TITLE
Used forceWeakRemove flag in undo OT

### DIFF
--- a/src/basecommand.js
+++ b/src/basecommand.js
@@ -148,7 +148,8 @@ export default class BaseCommand extends Command {
 				{
 					useRelations: true,
 					document: this.editor.model.document,
-					padWithNoOps: false
+					padWithNoOps: false,
+					forceWeakRemove: true
 				}
 			);
 

--- a/tests/undocommand.js
+++ b/tests/undocommand.js
@@ -266,13 +266,6 @@ describe( 'UndoCommand', () => {
 				for ( const item of model.createRangeIn( doc.graveyard ).getItems() ) {
 					expect( item.hasAttribute( 'key' ) ).to.be.false;
 				}
-
-				// Let's undo wrapping. This will remove the P element and leave us with empty root.
-				undo.execute( batch3 );
-				expect( root.maxOffset ).to.equal( 0 );
-
-				expect( editor.model.document.selection.getFirstRange().isEqual( r( 0, 0 ) ) ).to.be.true;
-				expect( editor.model.document.selection.isBackward ).to.be.false;
 			} );
 
 			it( 'should omit deltas with non-document operations', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Used `forceWeakRemove` flag in undo OT.