### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/undoui.js
+++ b/src/undoui.js
@@ -59,7 +59,10 @@ export default class UndoUI extends Plugin {
 
 			view.bind( 'isEnabled' ).to( command, 'isEnabled' );
 
-			this.listenTo( view, 'execute', () => editor.execute( name ) );
+			this.listenTo( view, 'execute', () => {
+				editor.execute( name );
+				editor.editing.view.focus();
+			} );
 
 			return view;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. 

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066
